### PR TITLE
#40 Не показываем пустые жанры

### DIFF
--- a/src/home/flibrary/logic/data/NavigationQueryExecutor.cpp
+++ b/src/home/flibrary/logic/data/NavigationQueryExecutor.cpp
@@ -18,7 +18,7 @@ namespace {
 
 constexpr auto AUTHORS_QUERY = "select AuthorID, FirstName, LastName, MiddleName from Authors";
 constexpr auto SERIES_QUERY = "select SeriesID, SeriesTitle from Series";
-constexpr auto GENRES_QUERY = "select GenreCode, GenreAlias, ParentCode from Genres";
+constexpr auto GENRES_QUERY = "select g.GenreCode, g.GenreAlias, g.ParentCode from Genres g where exists (select 42 from Genres c where c.ParentCode = g.GenreCode) or exists (select 42 from Genre_List l where l.GenreCode = g.GenreCode)";
 constexpr auto GROUPS_QUERY = "select GroupID, Title from Groups_User";
 constexpr auto ARCHIVES_QUERY = "select distinct Folder from Books";
 constexpr auto SEARCH_QUERY = "select SearchID, Title from Searches_User";

--- a/src/home/flibrary/version/build.h
+++ b/src/home/flibrary/version/build.h
@@ -1,1 +1,1 @@
-constexpr int BUILD_NUMBER = 2172 ;
+constexpr int BUILD_NUMBER = 2173 ;


### PR DESCRIPTION
Изменён запрос выборки жанров: выбираем только те, у которых есть дети или связанные книги. Вообще, по хорошему, надо бы оптимизировать: не писать пустые жанры в базу на этапе создания коллекции.