### PR TITLE
Bugfix/#453 Меню книг, дублирующее контекстное, удалено из главного меню

### DIFF
--- a/src/home/flibrary/gui/MainWindow.cpp
+++ b/src/home/flibrary/gui/MainWindow.cpp
@@ -480,15 +480,6 @@ private:
 					m_lineOption->SetSettingsKey(Constant::Settings::EXPORT_TEMPLATE_KEY, IScriptController::GetDefaultOutputFileNameTemplate());
 				});
 
-		connect(m_ui.menuBook,
-		        &QMenu::aboutToShow,
-		        &m_self,
-		        [&]
-		        {
-					m_ui.menuBook->clear();
-					m_booksWidget->FillMenu(*m_ui.menuBook);
-				});
-
 		connect(m_ui.actionPermanentLanguageFilter, &QAction::triggered, &m_self, [&](const bool checked) { m_settings->Set(Constant::Settings::KEEP_RECENT_LANG_FILTER_KEY, checked); });
 		connect(m_ui.actionGenerateIndexInpx, &QAction::triggered, &m_self, [&] { GenerateCollectionInpx(); });
 		connect(m_ui.actionShowCollectionCleaner, &QAction::triggered, &m_self, [&] { m_uiFactory->CreateCollectionCleaner()->exec(); });

--- a/src/home/flibrary/gui/MainWindow.ui
+++ b/src/home/flibrary/gui/MainWindow.ui
@@ -416,14 +416,8 @@
     <addaction name="actionCheckForUpdates"/>
     <addaction name="actionAbout"/>
    </widget>
-   <widget class="QMenu" name="menuBook">
-    <property name="title">
-     <string>&amp;Book</string>
-    </property>
-   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuCollection"/>
-   <addaction name="menuBook"/>
    <addaction name="menuSettings"/>
    <addaction name="menuHelp"/>
   </widget>

--- a/src/home/flibrary/version/build.h
+++ b/src/home/flibrary/version/build.h
@@ -1,1 +1,1 @@
-constexpr int BUILD_NUMBER = 6895 ;
+constexpr int BUILD_NUMBER = 6913 ;


### PR DESCRIPTION
Оно перестало работать, а как давно - я и не заметил. Ну и выпилить его нафиг.