### PR TITLE
Feature/#463 Сделана скрытая настройка для предотвращения переключения раскладки на старте

### DIFF
--- a/src/home/flibrary/gui/LocaleController.cpp
+++ b/src/home/flibrary/gui/LocaleController.cpp
@@ -19,7 +19,7 @@ namespace HomeCompa::Flibrary
 namespace
 {
 constexpr auto LOCALE = "ui/locale";
-constexpr auto CONTEXT = "LocaleController";
+constexpr auto SET_KEYBOARD_LAYOUT_ON_START = "ui/setKeyboardLayoutOnStart";
 }
 
 class LocaleController::Impl
@@ -38,7 +38,9 @@ public:
 	{
 		const auto currentLocale = Loc::GetLocale(*m_settings);
 		Util::QStringWrapper::SetLocale(currentLocale);
-		SetKeyboardLayout(currentLocale.toStdString());
+		if (m_settings->Get(SET_KEYBOARD_LAYOUT_ON_START, true))
+			SetKeyboardLayout(currentLocale.toStdString());
+
 		for (const auto* locale : Loc::LOCALES)
 		{
 			auto* action = menu.addAction(Loc::Tr(Loc::Ctx::LANG, locale), [&, locale] { SetLocale(locale); });

--- a/src/home/flibrary/version/build.h
+++ b/src/home/flibrary/version/build.h
@@ -1,1 +1,1 @@
-constexpr int BUILD_NUMBER = 6961 ;
+constexpr int BUILD_NUMBER = 6980 ;


### PR DESCRIPTION
`ui/setKeyboardLayoutOnStart=false`