### PR TITLE
Dev/#524 Удалены true && и false ||

### DIFF
--- a/src/home/flibrary/gui/TreeView.cpp
+++ b/src/home/flibrary/gui/TreeView.cpp
@@ -279,7 +279,7 @@ private: // ITreeViewController::IObserver
 				break;
 		}
 
-		if (true && IsOneOf(static_cast<BooksMenuAction>(item->GetData(MenuItem::Column::Id).toInt()), BooksMenuAction::SendAsArchive, BooksMenuAction::SendAsIs, BooksMenuAction::SendAsScript)
+		if (IsOneOf(static_cast<BooksMenuAction>(item->GetData(MenuItem::Column::Id).toInt()), BooksMenuAction::SendAsArchive, BooksMenuAction::SendAsIs, BooksMenuAction::SendAsScript)
 		    && item->GetData(MenuItem::Column::HasError).toInt())
 			m_uiFactory->ShowWarning(Loc::Tr(Loc::Ctx::ERROR, Loc::BOOKS_EXTRACT_ERROR));
 	}

--- a/src/home/flibrary/gui/dialogs/AddCollectionDialog.cpp
+++ b/src/home/flibrary/gui/dialogs/AddCollectionDialog.cpp
@@ -214,7 +214,7 @@ private:
 	{
 		ResetError();
 
-		return true && CheckName() && CheckDatabase() && CheckFolder();
+		return CheckName() && CheckDatabase() && CheckFolder();
 	}
 
 	[[nodiscard]] bool CheckName() const

--- a/src/home/flibrary/logic/ChangeNavigationController/GroupController.cpp
+++ b/src/home/flibrary/logic/ChangeNavigationController/GroupController.cpp
@@ -200,7 +200,7 @@ void GroupController::CreateNew(Callback callback) const
 
 void GroupController::Remove(Ids ids, Callback callback) const
 {
-	if (false || ids.empty() || m_impl->uiFactory->ShowQuestion(Tr(REMOVE_GROUP_CONFIRM).arg(ids.size()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
+	if (ids.empty() || m_impl->uiFactory->ShowQuestion(Tr(REMOVE_GROUP_CONFIRM).arg(ids.size()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
 		return;
 
 	m_impl->databaseUser->Execute({ "Remove groups",

--- a/src/home/flibrary/logic/ChangeNavigationController/SearchController.cpp
+++ b/src/home/flibrary/logic/ChangeNavigationController/SearchController.cpp
@@ -193,7 +193,7 @@ void SearchController::CreateNew(Callback callback)
 
 void SearchController::Remove(Ids ids, Callback callback) const
 {
-	if (false || ids.empty() || m_impl->uiFactory->ShowQuestion(Tr(REMOVE_SEARCH_CONFIRM).arg(ids.size()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
+	if (ids.empty() || m_impl->uiFactory->ShowQuestion(Tr(REMOVE_SEARCH_CONFIRM).arg(ids.size()), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
 		return;
 
 	m_impl->databaseUser->Execute({ "Remove search string",

--- a/src/home/flibrary/logic/extract/BooksExtractor.cpp
+++ b/src/home/flibrary/logic/extract/BooksExtractor.cpp
@@ -184,7 +184,7 @@ void Process(const std::filesystem::path& archiveFolder,
 		IScriptController::SetMacro(command.args, IScriptController::Macro::UserDestinationFolder, QDir::toNativeSeparators(dstFolder));
 		ILogicFactory::FillScriptTemplate(command.args, book);
 
-		if (false || progress.IsStopped() || !scriptController.Execute(command))
+		if (progress.IsStopped() || !scriptController.Execute(command))
 			return;
 	}
 }

--- a/src/home/flibrary/logic/model/FilteredProxyModel.cpp
+++ b/src/home/flibrary/logic/model/FilteredProxyModel.cpp
@@ -120,7 +120,7 @@ bool FilteredProxyModel::setData(const QModelIndex& index, const QVariant& value
 
 bool FilteredProxyModel::Check(const QVariant& value, const Qt::CheckState checkState)
 {
-	return Check(value, [&](const QModelIndex& index) { return true && index.data(Qt::CheckStateRole).value<Qt::CheckState>() != checkState && setData(index, checkState, Qt::CheckStateRole); });
+	return Check(value, [&](const QModelIndex& index) { return index.data(Qt::CheckStateRole).value<Qt::CheckState>() != checkState && setData(index, checkState, Qt::CheckStateRole); });
 }
 
 void FilteredProxyModel::Check(const QModelIndex& parent, const Qt::CheckState state)

--- a/src/home/flibrary/logic/model/SortFilterProxyModel.cpp
+++ b/src/home/flibrary/logic/model/SortFilterProxyModel.cpp
@@ -136,7 +136,7 @@ bool SortFilterProxyModel::filterAcceptsRow(const int sourceRow, const QModelInd
 {
 	const auto itemIndex = m_impl->m_sourceModel->index(sourceRow, 0, sourceParent);
 	assert(itemIndex.isValid());
-	return true && FilterAcceptsText(itemIndex) && FilterAcceptsLanguage(itemIndex) && FilterAcceptsRemoved(itemIndex);
+	return FilterAcceptsText(itemIndex) && FilterAcceptsLanguage(itemIndex) && FilterAcceptsRemoved(itemIndex);
 }
 
 bool SortFilterProxyModel::lessThan(const QModelIndex& sourceLeft, const QModelIndex& sourceRight) const
@@ -166,7 +166,7 @@ bool SortFilterProxyModel::FilterAcceptsText(const QModelIndex& index) const
 
 bool SortFilterProxyModel::FilterAcceptsLanguage(const QModelIndex& index) const
 {
-	return false || m_impl->m_languageFilter.isEmpty() || (index.data(Role::Type).value<ItemType>() == ItemType::Books && index.data(Role::Lang) == m_impl->m_languageFilter);
+	return m_impl->m_languageFilter.isEmpty() || (index.data(Role::Type).value<ItemType>() == ItemType::Books && index.data(Role::Lang) == m_impl->m_languageFilter);
 }
 
 bool SortFilterProxyModel::FilterAcceptsRemoved(const QModelIndex& index) const

--- a/src/home/flibrary/logic/model/script/ScriptSortFilterModel.cpp
+++ b/src/home/flibrary/logic/model/script/ScriptSortFilterModel.cpp
@@ -19,7 +19,7 @@ bool MoveRow(QSortFilterProxyModel& model, const QModelIndex& index, const int o
 	const auto indexTo = model.index(index.row() + offset, index.column(), index.parent());
 	const auto to = indexTo.data(Role::Number).toInt();
 
-	const auto result = true && model.setData(index, to, Role::Number) && model.setData(indexTo, from, Role::Number);
+	const auto result = model.setData(index, to, Role::Number) && model.setData(indexTo, from, Role::Number);
 
 	if (result)
 		model.invalidate();

--- a/src/home/flibrary/version/build.h
+++ b/src/home/flibrary/version/build.h
@@ -1,1 +1,1 @@
-constexpr int BUILD_NUMBER = 7373 ;
+constexpr int BUILD_NUMBER = 7374 ;

--- a/src/home/inpx/src/util/inpx.cpp
+++ b/src/home/inpx/src/util/inpx.cpp
@@ -77,7 +77,7 @@ Dictionary::const_iterator FindDefault(const Dictionary& container, const std::w
 
 bool IsComment(const std::wstring_view line)
 {
-	return false || std::size(line) < 3 || line.starts_with(COMMENT_START);
+	return std::size(line) < 3 || line.starts_with(COMMENT_START);
 }
 
 class Ini

--- a/src/home/tool/fb2cut/MainWindow.cpp
+++ b/src/home/tool/fb2cut/MainWindow.cpp
@@ -147,7 +147,7 @@ void MainWindow::SetSettings(Settings* settings)
 
 void MainWindow::CheckEnabled()
 {
-	const bool startDisabled = false || m_ui->actionInputFilesNotFound->isVisible() || m_ui->actionDstFolderNotExists->isVisible() || m_ui->actionFfmpegNotFound->isVisible();
+	const bool startDisabled = m_ui->actionInputFilesNotFound->isVisible() || m_ui->actionDstFolderNotExists->isVisible() || m_ui->actionFfmpegNotFound->isVisible();
 
 	m_ui->btnStart->setEnabled(!startDisabled);
 }

--- a/src/home/tool/fb2cut/settings.h
+++ b/src/home/tool/fb2cut/settings.h
@@ -37,7 +37,7 @@ struct ImageSettings
 
 	bool operator==(const ImageSettings& rhs) const noexcept
 	{
-		return true && maxSize == rhs.maxSize && quality == rhs.quality && save == rhs.save && grayscale == rhs.grayscale;
+		return maxSize == rhs.maxSize && quality == rhs.quality && save == rhs.save && grayscale == rhs.grayscale;
 	}
 };
 

--- a/src/home/zip/impl/remover.cpp
+++ b/src/home/zip/impl/remover.cpp
@@ -185,7 +185,7 @@ private: // IArchiveUpdateCallback
 		if (m_progress.OnCheckBreak())
 			return E_ABORT;
 
-		assert(false || "unexpected call");
+		assert(false && "unexpected call");
 		return S_OK;
 	}
 


### PR DESCRIPTION
Были нужны для красивого форматирования и разумных диффов. С clang-format'ом бесполезны.