### PR TITLE
Bugfix/#1205 Исправить выбор результата быстрого поиска

### DIFF
--- a/src/home/flibrary/gui/MainWindow.cpp
+++ b/src/home/flibrary/gui/MainWindow.cpp
@@ -1374,7 +1374,7 @@ private:
 			if (id <= 0)
 				return;
 
-			ILogicFactory::Lock(m_logicFactory)->FindBook("Search", QString::number(id));
+			m_navigationWidget->SetMode(static_cast<int>(NavigationMode::Search), QString::number(id));
 			searchController.reset();
 		});
 	}

--- a/src/home/flibrary/gui/TreeView.cpp
+++ b/src/home/flibrary/gui/TreeView.cpp
@@ -494,6 +494,24 @@ public:
 		return m_ui.treeView;
 	}
 
+	void SetMode(const int mode, const QString& id)
+	{
+		assert(IsNavigation());
+		const auto modeIndex = m_ui.cbMode->findData(mode, Qt::UserRole + 1);
+		if (modeIndex < 0)
+			return;
+
+		if (m_controller->GetModeIndex() != mode)
+			m_ui.cbMode->setCurrentIndex(modeIndex);
+
+		m_currentId = id;
+		m_settings->Set(GetRecentIdKey(), id);
+
+		const auto& model = *m_ui.treeView->model();
+		if (const auto matched = model.match(model.index(0, 0), Role::Id, id, 1, Qt::MatchFlag::MatchExactly | Qt::MatchFlag::MatchRecursive); !matched.isEmpty())
+			m_ui.treeView->setCurrentIndex(matched.front());
+	}
+
 	void OnBookTitleToSearchVisibleChanged() const
 	{
 		emit m_self.ValueGeometryChanged(Util::GetGlobalGeometry(*m_ui.value));
@@ -1447,6 +1465,11 @@ void TreeView::ShowRemoved(const bool showRemoved)
 QAbstractItemView* TreeView::GetView() const
 {
 	return m_impl->GetView();
+}
+
+void TreeView::SetMode(const int mode, const QString& id)
+{
+	m_impl->SetMode(mode, id);
 }
 
 void TreeView::OnBookTitleToSearchVisibleChanged() const

--- a/src/home/flibrary/gui/TreeView.h
+++ b/src/home/flibrary/gui/TreeView.h
@@ -50,6 +50,7 @@ public:
 	void               SetNavigationModeName(QString navigationModeName);
 	void               ShowRemoved(bool showRemoved);
 	QAbstractItemView* GetView() const;
+	void               SetMode(int mode, const QString& id);
 
 private slots:
 	void OnBookTitleToSearchVisibleChanged() const;


### PR DESCRIPTION
## Что исправлено

- Быстрый поиск переключает навигацию в режим «Поиск» для выбранного результата.
- Идентификатор результата сохраняется как текущий, соответствующий узел выделяется в дереве.
- Вместо предыдущего поискового запроса открывается именно выбранная книга.

## Проверка

- cmake --build build --target FLibrary --parallel
- Ручная проверка быстрого поиска на macOS.

Fixes #1205