### PR TITLE
Не сжимать колонки списка книг при первом открытии

### DIFF
--- a/src/home/flibrary/gui/TreeView.cpp
+++ b/src/home/flibrary/gui/TreeView.cpp
@@ -1179,15 +1179,18 @@ private:
 		{
 			for (auto i = 0, sz = header->count(); i < sz; ++i)
 			{
-				header->showSection(i);
-				header->resizeSection(i, header->minimumSectionSize());
+				const auto name   = header->model()->headerData(i, Qt::Horizontal, Role::HeaderName).toString();
+				const auto hidden = m_hiddenColumns.contains(name, Qt::CaseInsensitive);
+				header->setSectionHidden(i, hidden);
+				if (!hidden)
+					header->resizeSection(i, std::max(header->defaultSectionSize(), header->sectionSizeHint(i)));
 			}
 			return;
 		}
 
 		for (const auto [columnInfo, logicalIndex] : std::views::zip(columnInfoList, std::views::iota(0)))
 		{
-			header->resizeSection(logicalIndex, std::max(columnInfo.width, header->minimumSectionSize()));
+			header->resizeSection(logicalIndex, std::max(columnInfo.width, header->sectionSizeHint(logicalIndex)));
 			columnInfo.hidden ? header->hideSection(logicalIndex) : header->showSection(logicalIndex);
 		}
 


### PR DESCRIPTION
## Что исправлено

- При отсутствии сохранённой раскладки колонки получают читаемую ширину вместо минимальной.
- Ширина учитывает стандартный размер секции и размер заголовка.
- Настроенные скрытые колонки остаются скрытыми.

## Проверка

- cmake --build build --target FLibrary --parallel